### PR TITLE
fix: update container run options for coffeebreak job

### DIFF
--- a/.github/workflows/coffee.yml
+++ b/.github/workflows/coffee.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/redhat-appstudio-qe/qe-tools:latest
+      options: --user root
 
     steps:
       - name: Check out code


### PR DESCRIPTION
 * Coffee break jobs have been failing error looks to be related to Github actions issue #956. Trying workaround to leverage our container to run as root