### PR TITLE
chore:  move qe-tools image to konflux-ci

### DIFF
--- a/.github/workflows/coffee.yml
+++ b/.github/workflows/coffee.yml
@@ -9,8 +9,7 @@ jobs:
   coffee-break:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/redhat-appstudio-qe/qe-tools:latest
-
+      image: quay.io/konflux-ci/qe-tools:latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
https://issues.redhat.com/browse/KONFLUX-3569

- move images to konflux-ci org
