### PR TITLE
feat: test results analyzer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
 
       - name: Install required tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: linux
           goarch: amd64
-          goversion: "1.20"
+          goversion: "1.22"
           binary_name: qe-tools
           extra_files: config

--- a/.github/workflows/slack-message.yml
+++ b/.github/workflows/slack-message.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: 
-      image: golang:1.20
+      image: golang:1.22
 
     steps:
       - name: Check out code
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
 
       - name: Fetch URL Content
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.22.x]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ qe-tools
 vendor/
 coverage.out
 tmp
+analysis.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.10 AS builder
+FROM docker.io/library/golang:1.22.7 AS builder
 
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/analyzetestresults/analyzetestresults.go
+++ b/cmd/analyzetestresults/analyzetestresults.go
@@ -53,7 +53,7 @@ var AnalyzeTestResultsCmd = &cobra.Command{
 		failedTCReport := testresults.FailedTestCasesReport{}
 		failedTCReport.CollectTestFilesData(scanner.FilesPathMap, jUnitFilename, e2eTestRunLogFilename, clusterProvisionLogFilename)
 
-		if err := os.WriteFile(outputFilename, []byte(failedTCReport.GetFormattedReport()), 0o600); err != nil {
+		if err := os.WriteFile(outputFilename, []byte(testresults.GetFormattedReport(failedTCReport)), 0o600); err != nil {
 			return fmt.Errorf("failed to create a file with the test result analysis: %+v", err)
 		}
 		klog.Infof("analysis saved to %s", outputFilename)

--- a/cmd/analyzetestresults/analyzetestresults.go
+++ b/cmd/analyzetestresults/analyzetestresults.go
@@ -1,0 +1,221 @@
+package analyzetestresults
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bsm/ginkgo/v2/reporters"
+	"github.com/konflux-ci/qe-tools/pkg/oci"
+	"k8s.io/klog/v2"
+
+	"github.com/konflux-ci/qe-tools/pkg/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// FailureType collects the types of failures met in the PipelineRun
+type FailureType string
+
+const (
+	dropdownSummaryString = "Click to view logs"
+
+	// OtherFailure represents the type failure that hasn't been identified by the analyzer
+	OtherFailure FailureType = "otherFailure"
+	// ClusterCreationFailure represents the issue with provisioning a test cluster
+	ClusterCreationFailure FailureType = "clusterCreationFailure"
+	// TestRunFailure represents the issue with provisioning a test cluster
+	TestRunFailure FailureType = "testRunFailure"
+	// TestCaseFailure represents the issue with provisioning a test cluster
+	TestCaseFailure FailureType = "testCaseFailure"
+)
+
+var (
+	ociArtifactRef              string
+	clusterProvisionLogFilename string
+	jUnitFilename               string
+	e2eTestRunLogFilename       string
+	outputFilename              string
+)
+
+// FailedTestCasesReport collects the data about failures
+type FailedTestCasesReport struct {
+	headerString        string
+	failedTestCaseNames []string
+
+	clusterProvisionLog string
+	e2eTestLog          string
+
+	failureType FailureType
+}
+
+// getTestSuitesFromXMLFile returns all the JUnitTestSuites
+// present within a file with the given name
+func getTestSuitesFromXMLFile(scanner *oci.ArtifactScanner, filename string) (*reporters.JUnitTestSuites, error) {
+	overallJUnitSuites := &reporters.JUnitTestSuites{}
+
+	for _, file := range scanner.FilesPathMap {
+		if string(file.Filename) == filename {
+			if err := xml.Unmarshal([]byte(file.Content), overallJUnitSuites); err != nil {
+				klog.Warningf("cannot decode JUnit suite into xml: %+v", err)
+				return &reporters.JUnitTestSuites{}, err
+			}
+			return overallJUnitSuites, nil
+		}
+	}
+
+	return &reporters.JUnitTestSuites{}, fmt.Errorf("couldn't find the %s file", filename)
+}
+
+// setHeaderString initialises struct FailedTestCasesReport's
+// 'headerString' field based on phase at which PipelineRun failed
+func (f *FailedTestCasesReport) setHeaderString(overallJUnitSuites *reporters.JUnitTestSuites) {
+	if len(overallJUnitSuites.TestSuites) == 0 {
+		if f.clusterProvisionLog == "" && f.e2eTestLog == "" {
+			klog.Info("could not find any related artifacts")
+			f.failureType = OtherFailure
+			f.headerString = ":rotating_light: **Couldn't detect a specific failure, see the related PipelineRun for more details or consult with Konflux DevProd team.**\n"
+			return
+		}
+		if f.e2eTestLog != "" {
+			klog.Info("no JUnit file found - PipelineRun failed during running tests")
+			f.failureType = TestRunFailure
+			f.headerString = ":rotating_light: **No JUnit file found, see the log from running tests**: \n"
+			return
+		}
+		if f.clusterProvisionLog != "" {
+			klog.Info("failed to provision a cluster")
+			f.failureType = ClusterCreationFailure
+			f.headerString = ":rotating_light: **Failed to provision a cluster, see the log for more details**: \n"
+			return
+		}
+
+	} else {
+		klog.Info("The given PipelineRun failed while running tests")
+		f.failureType = TestCaseFailure
+		f.headerString = ":rotating_light: **Error occurred while running the E2E tests, list of failed Spec(s)**: \n"
+	}
+}
+
+// extractFailedTestCases initialises the FailedTestCasesReport struct's
+// 'failedTestCaseNames' field with the names of failed test cases
+// within given JUnitTestSuites -- if the given JUnitTestSuites is !nil.
+func (f *FailedTestCasesReport) extractFailedTestCases(overallJUnitSuites *reporters.JUnitTestSuites) {
+	switch f.failureType {
+	case OtherFailure:
+		return
+	case ClusterCreationFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.clusterProvisionLog)
+		f.failedTestCaseNames = append(f.failedTestCaseNames, testCaseEntry)
+		return
+	case TestRunFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.e2eTestLog)
+		f.failedTestCaseNames = append(f.failedTestCaseNames, testCaseEntry)
+		return
+	}
+	for _, testSuite := range overallJUnitSuites.TestSuites {
+		if testSuite.Failures > 0 || testSuite.Errors > 0 {
+			var tcMessage string
+			for _, tc := range testSuite.TestCases {
+				if tc.Failure != nil || tc.Error != nil {
+					klog.Infof("Found a Test Case (suiteName/testCaseName): %s/%s, that didn't pass", testSuite.Name, tc.Name)
+					switch {
+					case tc.Status == "timedout":
+						tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.SystemErr)
+					case tc.Failure != nil:
+						tcMessage = "```\n" + tc.Failure.Message + "\n```"
+					default:
+						tcMessage = "```\n" + tc.Error.Message + "\n```"
+					}
+
+					testCaseEntry := "* :arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + "\n" + tcMessage
+					f.failedTestCaseNames = append(f.failedTestCaseNames, testCaseEntry)
+				}
+			}
+		}
+	}
+}
+
+// getFormattedReport returns the full report as a string
+func (f *FailedTestCasesReport) getFormattedReport() string {
+	msg := f.headerString
+	for _, failedTCName := range f.failedTestCaseNames {
+		msg += fmt.Sprintf("\n %s\n", failedTCName)
+	}
+
+	return msg
+}
+
+func returnContentWrappedInDropdown(summary, content string) string {
+	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>"
+}
+
+// AnalyzeTestResultsCmd represents the analyze-test-results command
+var AnalyzeTestResultsCmd = &cobra.Command{
+	Use:   "analyze-test-results",
+	Short: "Command for analyzing test results",
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if viper.GetString(types.OciArtifactRefParamName) == "" {
+			_ = cmd.Usage()
+			return fmt.Errorf("parameter %q not provided, neither %s env var was set", types.OciArtifactRefParamName, types.OciArtifactRefEnv)
+		}
+		return nil
+	},
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ociArtifactRef = viper.GetString(types.OciArtifactRefParamName)
+
+		cfg := oci.ScannerConfig{
+			OciArtifactReference: ociArtifactRef,
+			FileNameFilter:       []string{types.JunitFilename, clusterProvisionLogFilename, e2eTestRunLogFilename},
+		}
+
+		scanner, err := oci.NewArtifactScanner(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to initialize artifact scanner: %+v", err)
+		}
+
+		if err := scanner.Run(); err != nil {
+			return fmt.Errorf("failed to scan artifact from %s: %+v", ociArtifactRef, err)
+		}
+
+		overallJUnitSuites, err := getTestSuitesFromXMLFile(scanner, jUnitFilename)
+		// make sure that the Prow job didn't fail while creating the cluster
+		if err != nil && !strings.Contains(err.Error(), fmt.Sprintf("couldn't find the %s file", jUnitFilename)) {
+			return fmt.Errorf("failed to get JUnitTestSuites from the file %s: %+v", jUnitFilename, err)
+		}
+
+		failedTCReport := FailedTestCasesReport{}
+
+		for _, file := range scanner.FilesPathMap {
+			if file.Filename == clusterProvisionLogFilename {
+				failedTCReport.clusterProvisionLog = file.Content
+			}
+			if file.Filename == e2eTestRunLogFilename {
+				failedTCReport.e2eTestLog = file.Content
+			}
+		}
+
+		failedTCReport.setHeaderString(overallJUnitSuites)
+		failedTCReport.extractFailedTestCases(overallJUnitSuites)
+
+		if err := os.WriteFile(outputFilename, []byte(failedTCReport.getFormattedReport()), 0o600); err != nil {
+			return fmt.Errorf("failed to create a file with the test result analysis: %+v", err)
+		}
+		klog.Infof("analysis saved to %s", outputFilename)
+
+		return nil
+	},
+}
+
+func init() {
+	AnalyzeTestResultsCmd.Flags().StringVar(&ociArtifactRef, types.OciArtifactRefParamName, "", "OCI artifact reference (e.g. \"quay.io/org/repo:oci-artifact-tag\")")
+	AnalyzeTestResultsCmd.Flags().StringVar(&jUnitFilename, types.JUnitFilenameParamName, "e2e-report.xml", "A name of the file containing JUnit report")
+	AnalyzeTestResultsCmd.Flags().StringVar(&clusterProvisionLogFilename, types.ClusterProvisionLogFileParamName, "cluster-provision.log", "A name of the file containing log from provisioning a testing cluster")
+	AnalyzeTestResultsCmd.Flags().StringVar(&e2eTestRunLogFilename, types.E2ETestRunLogFileParamName, "e2e-tests.log", "A name of the file containing log from running tests")
+	AnalyzeTestResultsCmd.Flags().StringVar(&outputFilename, types.OutputFilenameParamName, "analysis.md", "A name of the file to store the analysis output in")
+
+	_ = viper.BindPFlag(types.OciArtifactRefParamName, AnalyzeTestResultsCmd.Flags().Lookup(types.OciArtifactRefParamName))
+	_ = viper.BindEnv(types.OciArtifactRefParamName, types.OciArtifactRefEnv)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/konflux-ci/qe-tools/cmd/analyzetestresults"
 	"github.com/konflux-ci/qe-tools/cmd/estimate"
 	"github.com/konflux-ci/qe-tools/cmd/webhook"
 
@@ -50,6 +51,7 @@ func init() {
 	rootCmd.AddCommand(sendslackmessage.SendSlackMessageCmd)
 	rootCmd.AddCommand(webhook.WebhookCmd)
 	rootCmd.AddCommand(estimate.EstimateTimeToReviewCmd)
+	rootCmd.AddCommand(analyzetestresults.AnalyzeTestResultsCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/konflux-ci/qe-tools
 
-go 1.20
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.38.0
 	github.com/GoogleCloudPlatform/testgrid v0.0.170
+	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/daixiang0/gci v0.13.1
 	github.com/go-critic/go-critic v0.11.1
 	github.com/google/go-github/v56 v56.0.0

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,7 @@ github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -804,6 +805,8 @@ github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHf
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/ccojocar/zxcvbn-go v1.0.2 h1:na/czXU8RrhXO4EZme6eQJLR4PzcGsahsBOAwU6I3Vg=
 github.com/ccojocar/zxcvbn-go v1.0.2/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
@@ -825,6 +828,7 @@ github.com/cjwagner/httpcache v0.0.0-20230907212505-d4841bbad466 h1:eUjwn08FDjbj
 github.com/cjwagner/httpcache v0.0.0-20230907212505-d4841bbad466/go.mod h1:f7xZ2fRr8CqTp834KCxLW2pOXC/raqwhTbEvtxu/lRo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.13.0 h1:2zxDS8RyY1/wVPULGGbdgniGXSzLaRJVl136fLXGsYw=
+github.com/cloudevents/sdk-go/v2 v2.13.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -840,6 +844,7 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101 h1:7To3pQ+pZo0i3dsWEbinPNFs5gPSBOsJtx3wTT94VBY=
+github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cristalhq/acmd v0.11.2 h1:ITIWtBRiYbmzk+i8xQgH2RzfCVMII+dOd0CtGWVIhaU=
@@ -849,6 +854,7 @@ github.com/daixiang0/gci v0.13.1/go.mod h1:JyUVY/ZKzBjrzLOm2UQDZohEZ2HlfX72jONBV
 github.com/dave/dst v0.27.2 h1:4Y5VFTkhGLC1oddtNwuxxe36pnyLxMFXT51FOzH8Ekc=
 github.com/dave/dst v0.27.2/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
 github.com/dave/jennifer v1.5.0 h1:HmgPN93bVDpkQyYbqhCHj5QlgvUkvEOzMyEvKLgCRrg=
+github.com/dave/jennifer v1.5.0/go.mod h1:4MnyiFIlZS3l5tSDn8VnzE6ffAhYBMB2SZntBsZGUok=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -879,6 +885,7 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
+github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -894,6 +901,7 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -945,8 +953,10 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-toolsmith/astcast v1.1.0 h1:+JN9xZV1A+Re+95pgnMgDboWNVnIMMQXwfBwLRPgSC8=
 github.com/go-toolsmith/astcast v1.1.0/go.mod h1:qdcuFWeGGS2xX5bLM/c3U9lewg7+Zu4mr+xPwZIB4ZU=
 github.com/go-toolsmith/astcopy v1.1.0 h1:YGwBN0WM+ekI/6SS6+52zLDEf8Yvp3n2seZITCUBt5s=
@@ -975,6 +985,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
+github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1073,6 +1084,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQNvHSdIE7iqsQxK1P41mySCvssg=
+github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.0/go.mod h1:OJpEgntRZo8ugHpF9hkoLJbS5dSI20XZeXJ9JVywLlM=
 github.com/google/s2a-go v0.1.3/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -1129,6 +1141,7 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -1138,6 +1151,7 @@ github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
+github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -1157,6 +1171,7 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
@@ -1171,6 +1186,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -1217,6 +1233,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
@@ -1253,6 +1270,7 @@ github.com/onsi/gomega v1.27.1/go.mod h1:aHX5xOykVYzWOV4WqQy0sy8BQptgukenXpCXfad
 github.com/onsi/gomega v1.27.3/go.mod h1:5vG284IBtfDAmDyrK+eGyZmUgUlmi+Wngqo557cZ6Gw=
 github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
+github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/orijtech/structslop v0.0.8 h1:xkiOOdE3Obe82vdQvrb4bsjCGAUqQEo6Ln3r4yFMzGw=
@@ -1274,6 +1292,7 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
@@ -1322,6 +1341,7 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
@@ -1333,6 +1353,7 @@ github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWR
 github.com/securego/gosec/v2 v2.19.0 h1:gl5xMkOI0/E6Hxx0XCY2XujA3V7SNSefA8sC+3f1gnk=
 github.com/securego/gosec/v2 v2.19.0/go.mod h1:hOkDcHz9J/XIgIlPDXalxjeVYsHxoWUc5zJSHxcB8YM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 h1:N5B+JgvM/DVYIxreItPJMM3yWrNO/GB2q4nESrtBisM=
 github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
@@ -1418,6 +1439,7 @@ go.opentelemetry.io/otel v1.23.0/go.mod h1:YCycw9ZeKhcJFrb34iVSkyT0iczq/zYDtZYFu
 go.opentelemetry.io/otel/metric v1.23.0 h1:pazkx7ss4LFVVYSxYew7L5I6qvLXHA0Ap2pwV+9Cnpo=
 go.opentelemetry.io/otel/metric v1.23.0/go.mod h1:MqUW2X2a6Q8RN96E2/nqNoT+z9BSms20Jb7Bbp+HiTo=
 go.opentelemetry.io/otel/sdk v1.21.0 h1:FTt8qirL1EysG6sTQRZ5TokkU8d0ugCj8htOgThZXQ8=
+go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/trace v1.23.0 h1:37Ik5Ib7xfYVb4V1UtnT97T1jI+AoIYkJyPkuL4iJgI=
 go.opentelemetry.io/otel/trace v1.23.0/go.mod h1:GSGTbIClEsuZrGIzoEHqsVfxgn5UkggkflQwDScNUsk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -1427,6 +1449,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
@@ -1871,6 +1894,7 @@ golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNq
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=

--- a/pkg/oci/artifact_scanner.go
+++ b/pkg/oci/artifact_scanner.go
@@ -1,0 +1,96 @@
+package oci
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+)
+
+// NewArtifactScanner creates a new instance of ArtifactScanner.
+// It requires a valid ScannerConfig.
+func NewArtifactScanner(cfg ScannerConfig) (*ArtifactScanner, error) {
+	return &ArtifactScanner{
+		config:       cfg,
+		FilesPathMap: FilesPathMap{},
+	}, nil
+}
+
+// Run method processes pulls the OCI artifact and stores required files (their path and content)
+// in the map (ArtifactsFilesPathMap).
+func (as *ArtifactScanner) Run() error {
+	artifactDirPath, err := os.MkdirTemp("", "artifact-content")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary director for pulling OCI artifact to: %+v", err)
+	}
+	as.artifactDirPath = artifactDirPath
+
+	if err := as.pullAndExtractOciArtifact(); err != nil {
+		return fmt.Errorf("failed to pull OCI artifact: %+v", err)
+	}
+
+	if err := as.processExtractedFiles(); err != nil {
+		return fmt.Errorf("failed to process extracted files: %+v", err)
+	}
+
+	return nil
+}
+
+func (as *ArtifactScanner) pullAndExtractOciArtifact() error {
+	app := "oras"
+	args := []string{"pull", as.config.OciArtifactReference, "--output", as.artifactDirPath}
+	// #nosec G204
+	cmd := exec.Command(app, args...)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// processExtractedFiles is a helper function to process extracted files.
+func (as *ArtifactScanner) processExtractedFiles() error {
+	err := filepath.Walk(as.artifactDirPath, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to visit file in path %s: %+v", filePath, err)
+		}
+		if as.isRequiredFile(filePath) {
+			if err := as.initArtifactsFilesPathMap(info.Name(), filePath); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	return err
+}
+
+// initArtifactsFilesPathMap is  function to initialise/update the ArtifactsFilesPathMap with content
+// of a file with given file path and file name
+func (as *ArtifactScanner) initArtifactsFilesPathMap(fileName, filePath string) error {
+	file, err := os.Open(filepath.Clean(filePath))
+	if err != nil {
+		return err
+	}
+	fileData, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	artifact := Artifact{Content: string(fileData), Filename: fileName}
+
+	as.FilesPathMap[FilePath(filePath)] = artifact
+
+	return nil
+}
+
+// isRequiredFile is a helper function to check if a file with given 'ArtifactFullPath',
+// matches the file-name filter(s) defined within ScannerConfig struct
+func (as *ArtifactScanner) isRequiredFile(filePath string) bool {
+	return slices.ContainsFunc(as.config.FileNameFilter, func(s string) bool {
+		re := regexp.MustCompile(s)
+		return re.MatchString(filePath)
+	})
+}

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -1,0 +1,28 @@
+package oci
+
+// ArtifactScanner is used for pulling and extracting OCI artifact
+// and scanning and storing files found in extracted content
+type ArtifactScanner struct {
+	config          ScannerConfig
+	artifactDirPath string
+	FilesPathMap    FilesPathMap
+}
+
+// ScannerConfig contains fields required
+// for scanning files with ArtifactScanner
+type ScannerConfig struct {
+	OciArtifactReference string
+	FileNameFilter       []string
+}
+
+// FilesPathMap - e.g. "e2e-test/e2e-report.xml": {Content: "<file-content>", Filename: "e2e-report.xml"}
+type FilesPathMap map[FilePath]Artifact
+
+// FilePath represents the full path of the file from the root directory of the extracted OCI artifact
+type FilePath string
+
+// Artifact stores the file name of the artifact and the content of the file
+type Artifact struct {
+	Content  string
+	Filename string
+}

--- a/pkg/testresults/formatter.go
+++ b/pkg/testresults/formatter.go
@@ -1,0 +1,73 @@
+package testresults
+
+import (
+	"fmt"
+)
+
+// extractFailedTestCasesBody initialises the FailedTestCasesReport struct's
+// 'failedTestCaseNames' field with the names of failed test cases
+// within given JUnitTestSuites -- if the given JUnitTestSuites is !nil.
+func (f *FailedTestCasesReport) extractFailedTestCasesBody() {
+	switch f.FailureType {
+	case OtherFailure:
+		return
+	case ClusterCreationFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.ClusterProvisionLog)
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+		return
+	case TestRunFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.E2ETestLog)
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+		return
+	}
+	ftc := f.GetFailedTestCases()
+	for _, tc := range ftc {
+		var tcMessage string
+		switch {
+		case tc.Status == "timedout":
+			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.SystemErr)
+		case tc.Failure != nil:
+			tcMessage = "```\n" + tc.Failure.Message + "\n```"
+		default:
+			tcMessage = "```\n" + tc.Error.Message + "\n```"
+		}
+
+		testCaseEntry := "* :arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + "\n" + tcMessage
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+	}
+}
+
+// setHeaderString initialises sets 'headerString' field for the report summary
+// based on phase at which PipelineRun failed
+func (f *FailedTestCasesReport) setHeaderString() {
+	switch f.FailureType {
+	case OtherFailure:
+		f.HeaderString = ":rotating_light: **Couldn't detect a specific failure, see the related PipelineRun for more details or consult with Konflux DevProd team.**\n"
+		return
+	case TestRunFailure:
+		f.HeaderString = ":rotating_light: **No JUnit file found, see the log from running tests**: \n"
+		return
+	case ClusterCreationFailure:
+		f.HeaderString = ":rotating_light: **Failed to provision a cluster, see the log for more details**: \n"
+		return
+	case TestCaseFailure:
+		f.HeaderString = ":rotating_light: **Error occurred while running the E2E tests, list of failed Spec(s)**: \n"
+	}
+}
+
+// GetFormattedReport returns the full report (test run analysis) as a string
+func (f *FailedTestCasesReport) GetFormattedReport() (report string) {
+	f.setHeaderString()
+	f.extractFailedTestCasesBody()
+
+	report = f.HeaderString
+	for _, failedTCName := range f.FailedTestCaseNames {
+		report += fmt.Sprintf("\n %s\n", failedTCName)
+	}
+
+	return
+}
+
+func returnContentWrappedInDropdown(summary, content string) string {
+	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>"
+}

--- a/pkg/testresults/results.go
+++ b/pkg/testresults/results.go
@@ -2,7 +2,6 @@ package testresults
 
 import (
 	"encoding/xml"
-	"fmt"
 
 	"github.com/bsm/ginkgo/v2/reporters"
 	"github.com/konflux-ci/qe-tools/pkg/oci"
@@ -80,70 +79,6 @@ func (f *FailedTestCasesReport) CollectTestFilesData(fpm oci.FilesPathMap, junit
 	f.FailureType = OtherFailure
 }
 
-// setHeaderString initialises sets 'headerString' field for the report summary
-// based on phase at which PipelineRun failed
-func (f *FailedTestCasesReport) setHeaderString() {
-	switch f.FailureType {
-	case OtherFailure:
-		f.HeaderString = ":rotating_light: **Couldn't detect a specific failure, see the related PipelineRun for more details or consult with Konflux DevProd team.**\n"
-		return
-	case TestRunFailure:
-		f.HeaderString = ":rotating_light: **No JUnit file found, see the log from running tests**: \n"
-		return
-	case ClusterCreationFailure:
-		f.HeaderString = ":rotating_light: **Failed to provision a cluster, see the log for more details**: \n"
-		return
-	case TestCaseFailure:
-		f.HeaderString = ":rotating_light: **Error occurred while running the E2E tests, list of failed Spec(s)**: \n"
-	}
-}
-
-// extractFailedTestCasesBody initialises the FailedTestCasesReport struct's
-// 'failedTestCaseNames' field with the names of failed test cases
-// within given JUnitTestSuites -- if the given JUnitTestSuites is !nil.
-func (f *FailedTestCasesReport) extractFailedTestCasesBody() {
-	switch f.FailureType {
-	case OtherFailure:
-		return
-	case ClusterCreationFailure:
-		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.ClusterProvisionLog)
-		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
-		return
-	case TestRunFailure:
-		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.E2ETestLog)
-		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
-		return
-	}
-	ftc := f.GetFailedTestCases()
-	for _, tc := range ftc {
-		var tcMessage string
-		switch {
-		case tc.Status == "timedout":
-			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.SystemErr)
-		case tc.Failure != nil:
-			tcMessage = "```\n" + tc.Failure.Message + "\n```"
-		default:
-			tcMessage = "```\n" + tc.Error.Message + "\n```"
-		}
-
-		testCaseEntry := "* :arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + "\n" + tcMessage
-		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
-	}
-}
-
-// GetFormattedReport returns the full report (test run analysis) as a string
-func (f *FailedTestCasesReport) GetFormattedReport() (report string) {
-	f.setHeaderString()
-	f.extractFailedTestCasesBody()
-
-	report = f.HeaderString
-	for _, failedTCName := range f.FailedTestCaseNames {
-		report += fmt.Sprintf("\n %s\n", failedTCName)
-	}
-
-	return
-}
-
 // GetFailedTestCases returns the list of JUnit test cases that failed
 func (f *FailedTestCasesReport) GetFailedTestCases() (ftc []reporters.JUnitTestCase) {
 	for _, testSuite := range f.JUnitTestSuites.TestSuites {
@@ -157,8 +92,4 @@ func (f *FailedTestCasesReport) GetFailedTestCases() (ftc []reporters.JUnitTestC
 		}
 	}
 	return
-}
-
-func returnContentWrappedInDropdown(summary, content string) string {
-	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>"
 }

--- a/pkg/testresults/results.go
+++ b/pkg/testresults/results.go
@@ -12,8 +12,6 @@ import (
 type FailureType string
 
 const (
-	dropdownSummaryString = "Click to view logs"
-
 	// OtherFailure represents the type failure that hasn't been identified by the analyzer
 	OtherFailure FailureType = "otherFailure"
 	// ClusterCreationFailure represents the issue with provisioning a test cluster
@@ -27,9 +25,6 @@ const (
 // FailedTestCasesReport collects the data about failures
 type FailedTestCasesReport struct {
 	JUnitTestSuites *reporters.JUnitTestSuites
-
-	HeaderString        string
-	FailedTestCaseNames []string
 
 	ClusterProvisionLog string
 	E2ETestLog          string

--- a/pkg/testresults/results.go
+++ b/pkg/testresults/results.go
@@ -1,0 +1,164 @@
+package testresults
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/bsm/ginkgo/v2/reporters"
+	"github.com/konflux-ci/qe-tools/pkg/oci"
+	"k8s.io/klog/v2"
+)
+
+// FailureType collects the types of failures met in the PipelineRun
+type FailureType string
+
+const (
+	dropdownSummaryString = "Click to view logs"
+
+	// OtherFailure represents the type failure that hasn't been identified by the analyzer
+	OtherFailure FailureType = "otherFailure"
+	// ClusterCreationFailure represents the issue with provisioning a test cluster
+	ClusterCreationFailure FailureType = "clusterCreationFailure"
+	// TestRunFailure represents the issue with running the test command
+	TestRunFailure FailureType = "testRunFailure"
+	// TestCaseFailure represents the issue in the test suite (i.e. test case has failed)
+	TestCaseFailure FailureType = "testCaseFailure"
+)
+
+// FailedTestCasesReport collects the data about failures
+type FailedTestCasesReport struct {
+	JUnitTestSuites *reporters.JUnitTestSuites
+
+	HeaderString        string
+	FailedTestCaseNames []string
+
+	ClusterProvisionLog string
+	E2ETestLog          string
+
+	FailureType FailureType
+}
+
+// CollectTestFilesData inspects the FilesPathMap data and based on the supplied
+// names for JUnit, E2E run log and cluster provision log file names determines
+// the cause of the PipelineRun failure
+func (f *FailedTestCasesReport) CollectTestFilesData(fpm oci.FilesPathMap, junitFilename, e2eTestRunLogFilename, clusterProvisionLogFilename string) {
+	f.JUnitTestSuites = &reporters.JUnitTestSuites{}
+
+	for _, file := range fpm {
+		if string(file.Filename) == junitFilename {
+			if err := xml.Unmarshal([]byte(file.Content), f.JUnitTestSuites); err != nil {
+				klog.Warningf("cannot decode JUnit suite into xml: %+v", err)
+			}
+			f.FailureType = TestCaseFailure
+			klog.Info("the given PipelineRun failed on a test case failure")
+			return
+		}
+	}
+
+	for _, file := range fpm {
+		if file.Filename == e2eTestRunLogFilename {
+			f.E2ETestLog = file.Content
+		}
+		if file.Filename == clusterProvisionLogFilename {
+			f.ClusterProvisionLog = file.Content
+		}
+	}
+
+	if f.E2ETestLog != "" {
+		klog.Info("no JUnit file found - PipelineRun failed during running tests")
+		f.FailureType = TestRunFailure
+		return
+	}
+
+	if f.ClusterProvisionLog != "" {
+		klog.Info("failed to provision a cluster")
+		f.FailureType = ClusterCreationFailure
+		return
+	}
+
+	klog.Info("could not find any related artifacts")
+	f.FailureType = OtherFailure
+}
+
+// setHeaderString initialises sets 'headerString' field for the report summary
+// based on phase at which PipelineRun failed
+func (f *FailedTestCasesReport) setHeaderString() {
+	switch f.FailureType {
+	case OtherFailure:
+		f.HeaderString = ":rotating_light: **Couldn't detect a specific failure, see the related PipelineRun for more details or consult with Konflux DevProd team.**\n"
+		return
+	case TestRunFailure:
+		f.HeaderString = ":rotating_light: **No JUnit file found, see the log from running tests**: \n"
+		return
+	case ClusterCreationFailure:
+		f.HeaderString = ":rotating_light: **Failed to provision a cluster, see the log for more details**: \n"
+		return
+	case TestCaseFailure:
+		f.HeaderString = ":rotating_light: **Error occurred while running the E2E tests, list of failed Spec(s)**: \n"
+	}
+}
+
+// extractFailedTestCasesBody initialises the FailedTestCasesReport struct's
+// 'failedTestCaseNames' field with the names of failed test cases
+// within given JUnitTestSuites -- if the given JUnitTestSuites is !nil.
+func (f *FailedTestCasesReport) extractFailedTestCasesBody() {
+	switch f.FailureType {
+	case OtherFailure:
+		return
+	case ClusterCreationFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.ClusterProvisionLog)
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+		return
+	case TestRunFailure:
+		testCaseEntry := returnContentWrappedInDropdown(dropdownSummaryString, f.E2ETestLog)
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+		return
+	}
+	ftc := f.GetFailedTestCases()
+	for _, tc := range ftc {
+		var tcMessage string
+		switch {
+		case tc.Status == "timedout":
+			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.SystemErr)
+		case tc.Failure != nil:
+			tcMessage = "```\n" + tc.Failure.Message + "\n```"
+		default:
+			tcMessage = "```\n" + tc.Error.Message + "\n```"
+		}
+
+		testCaseEntry := "* :arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + "\n" + tcMessage
+		f.FailedTestCaseNames = append(f.FailedTestCaseNames, testCaseEntry)
+	}
+}
+
+// GetFormattedReport returns the full report (test run analysis) as a string
+func (f *FailedTestCasesReport) GetFormattedReport() (report string) {
+	f.setHeaderString()
+	f.extractFailedTestCasesBody()
+
+	report = f.HeaderString
+	for _, failedTCName := range f.FailedTestCaseNames {
+		report += fmt.Sprintf("\n %s\n", failedTCName)
+	}
+
+	return
+}
+
+// GetFailedTestCases returns the list of JUnit test cases that failed
+func (f *FailedTestCasesReport) GetFailedTestCases() (ftc []reporters.JUnitTestCase) {
+	for _, testSuite := range f.JUnitTestSuites.TestSuites {
+		if testSuite.Failures > 0 || testSuite.Errors > 0 {
+			for _, tc := range testSuite.TestCases {
+				if tc.Failure != nil || tc.Error != nil {
+					klog.Infof("Found a Test Case (suiteName/testCaseName): %s/%s, that didn't pass", testSuite.Name, tc.Name)
+					ftc = append(ftc, tc)
+				}
+			}
+		}
+	}
+	return
+}
+
+func returnContentWrappedInDropdown(summary, content string) string {
+	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>"
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,12 +2,18 @@ package types
 
 // Constants common across the whole project
 const (
-	ArtifactDirEnv string = "ARTIFACT_DIR"
-	GithubTokenEnv string = "GITHUB_TOKEN" // #nosec G101
-	ProwJobIDEnv   string = "PROW_JOB_ID"
+	ArtifactDirEnv    string = "ARTIFACT_DIR"
+	GithubTokenEnv    string = "GITHUB_TOKEN" // #nosec G101
+	ProwJobIDEnv      string = "PROW_JOB_ID"
+	OciArtifactRefEnv string = "OCI_REF"
 
-	ArtifactDirParamName string = "artifact-dir"
-	ProwJobIDParamName   string = "prow-job-id"
+	ArtifactDirParamName             string = "artifact-dir"
+	ProwJobIDParamName               string = "prow-job-id"
+	OciArtifactRefParamName          string = "oci-ref"
+	ClusterProvisionLogFileParamName string = "cluster-provision-log-name"
+	E2ETestRunLogFileParamName       string = "e2e-log-name"
+	JUnitFilenameParamName           string = "junit-report-name"
+	OutputFilenameParamName          string = "output-file"
 
 	JunitFilename string = `/(j?unit|e2e).*\.xml`
 )


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-43

### Verification
1. Build
```bash
➜ make build
```


2. Help command (should give you a good overview of options you have with this CLI tool)
```bash
➜  ./qe-tools analyze-test-results -h                                                                                                      
Command for analyzing test results

Usage:
  qe-tools analyze-test-results [flags]

Flags:
      --cluster-provision-log-name string   A name of the file containing log from provisioning a testing cluster (default "cluster-provision.log")
      --e2e-log-name string                 A name of the file containing log from running tests (default "e2e-tests.log")
  -h, --help                                help for analyze-test-results
      --junit-report-name string            A name of the file containing JUnit report (default "e2e-report.xml")
      --oci-ref string                      OCI artifact reference (e.g. "quay.io/org/repo:oci-artifact-tag")
      --output-file string                  A name of the file to store the analysis output in (default "analysis.md")

Global Flags:
      --config string   config file (default is $HOME/.qe-tools.yaml)
```

3.  Analyse an OCI artifact with **failed test case** (i.e. JUnit file is present in the OCI artifact)
```bash
➜  ./qe-tools analyze-test-results --oci-ref quay.io/psturc/oci-artifacts:test-case-failure
# the analysis is outputted to analysis.md file
```
[link to the content of `analysis.md` file](https://gist.github.com/psturc/d9f80deae60e17967f2b3adaf4fa1113#file-test-case-failure-md)


4.  Analyse an OCI artifact with **failed test run** (i.e. something got wrong during running the test and no JUnit file is present in the OCI artifact)
```bash
➜ ./qe-tools analyze-test-results --oci-ref quay.io/psturc/oci-artifacts:no-junit
```
[link to the content of `analysis.md` file](https://gist.github.com/psturc/d9f80deae60e17967f2b3adaf4fa1113#file-e2e-run-failure-md)


5.  Analyse an OCI artifact with **failed cluster provisioning** (i.e. OCI artifact contains log from provisioning a cluster)
```bash
➜  ./qe-tools analyze-test-results --oci-ref quay.io/psturc/oci-artifacts:cluster-provision-failure
```
[link to the content of `analysis.md` file](https://gist.github.com/psturc/d9f80deae60e17967f2b3adaf4fa1113#file-cluster-provision-failure-md)


6.  Analyse an OCI artifact with no JUnit file, no log files (i.e. something got probably wrong even before provisioning a cluster)
```bash
➜ ./qe-tools analyze-test-results --oci-ref quay.io/psturc/oci-artifacts:cluster-provision-failure --cluster-provision-log-name blabla.log
```
[link to the content of `analysis.md` file](https://gist.github.com/psturc/d9f80deae60e17967f2b3adaf4fa1113#file-unknown-failure-md)
