### PR TITLE
fix: make test case logs collapsed by default

### DIFF
--- a/cmd/oci/download.go
+++ b/cmd/oci/download.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/konflux-ci/qe-tools/pkg/oci"
+	"github.com/konflux-ci/qe-tools/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -119,7 +120,7 @@ Examples:
 
 		// If repo is specified, call helper function to download from a single repository
 		if opts.repo != "" {
-			repo, tag, err := parseRepoAndTag(opts.repo)
+			repo, tag, err := utils.ParseRepoAndTag(opts.repo)
 			if err != nil {
 				return err
 			}
@@ -190,24 +191,6 @@ Examples:
 
 		return nil
 	},
-}
-
-// parseRepoAndTag extracts the repository and tag from the given repo flag.
-func parseRepoAndTag(repoFlag string) (string, string, error) {
-	// Ensure the repoFlag starts with 'quay.io/'
-	if !strings.HasPrefix(repoFlag, "quay.io/") {
-		return "", "", fmt.Errorf("the repository must start with 'quay.io/'")
-	}
-
-	// Remove 'quay.io/' prefix and split the repo and tag using the ':' character
-	repoFlag = strings.TrimPrefix(repoFlag, "quay.io/")
-	parts := strings.SplitN(repoFlag, ":", 2)
-
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("tag is missing in the repo flag")
-	}
-
-	return parts[0], parts[1], nil
 }
 
 // parseDuration handles the custom duration format

--- a/pkg/testresults/formatter.go
+++ b/pkg/testresults/formatter.go
@@ -25,12 +25,12 @@ func extractFailedTestCasesBody(f FailedTestCasesReport) (failedTestCasesBody []
 		case tc.Status == "timedout":
 			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.SystemErr)
 		case tc.Failure != nil:
-			tcMessage = "```\n" + tc.Failure.Message + "\n```"
+			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.Failure.Message)
 		default:
-			tcMessage = "```\n" + tc.Error.Message + "\n```"
+			tcMessage = returnContentWrappedInDropdown(dropdownSummaryString, tc.Error.Message)
 		}
 
-		testCaseEntry := "* :arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + "\n" + tcMessage
+		testCaseEntry := ":arrow_right: " + "[**`" + tc.Status + "`**] " + tc.Name + tcMessage
 		failedTestCasesBody = append(failedTestCasesBody, testCaseEntry)
 	}
 	return
@@ -64,5 +64,5 @@ func GetFormattedReport(report FailedTestCasesReport) (formattedReport string) {
 }
 
 func returnContentWrappedInDropdown(summary, content string) string {
-	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>"
+	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>\n\n---"
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseRepoAndTag extracts the quay.io repository and tag from the given repo flag.
+func ParseRepoAndTag(repoFlag string) (string, string, error) {
+	// Ensure the repoFlag starts with 'quay.io/'
+	if !strings.HasPrefix(repoFlag, "quay.io/") {
+		return "", "", fmt.Errorf("the repository must start with 'quay.io/'")
+	}
+
+	// Remove 'quay.io/' prefix and split the repo and tag using the ':' character
+	repoFlag = strings.TrimPrefix(repoFlag, "quay.io/")
+	parts := strings.SplitN(repoFlag, ":", 2)
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("tag is missing in the repo flag")
+	}
+
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-9

### Description
* long failed test cases logs can make the analysis report not easy to read, hence this PR introduces formatting enhancement that makes every test cases log collapsed - it can be uncollapsed by clicking the arrow button - [see an example of a new formatting](https://gist.github.com/psturc/d9f80deae60e17967f2b3adaf4fa1113#file-improved-formatting-logs-collapsed-md)

### Additional changes
* the `analyze-test-results` command depended on oras CLI binary being present in `$PATH` - this PR removes that dependency and uses the qe-tools' `oci` package to pull OCI artifact used for analysis