### PR TITLE
fix: wrapped code formatting

### DIFF
--- a/pkg/testresults/formatter.go
+++ b/pkg/testresults/formatter.go
@@ -64,5 +64,5 @@ func GetFormattedReport(report FailedTestCasesReport) (formattedReport string) {
 }
 
 func returnContentWrappedInDropdown(summary, content string) string {
-	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>\n\n---"
+	return "<details><summary>" + summary + "</summary><br>\n<pre>" + content + "</pre></details>\n\n---"
 }


### PR DESCRIPTION
wrapped code blocks have better (more readable) indentation

# Before

 :arrow_right: [**`failed`**] [It] [build-service-suite Build service E2E tests] test of component update with renovate github when components are created in same namespace should lead to a nudge PR creation for child component  [build-service, renovate, multi-component]<details><summary>Click to view logs</summary><br><pre>Timed out after 1200.001s.
timed out when waiting for component nudge PR to be created in build-nudge-child repository
Expected
    <bool>: false
to be true</pre></details>

---

# After

 :arrow_right: [**`failed`**] [It] [build-service-suite Build service E2E tests] test of component update with renovate github when components are created in same namespace should lead to a nudge PR creation for child component  [build-service, renovate, multi-component]<details><summary>Click to view logs</summary><br>
<pre>Timed out after 1200.001s.
timed out when waiting for component nudge PR to be created in build-nudge-child repository
Expected
    <bool>: false
to be true</pre></details>

---