### PR TITLE
fix: analyzer: truncate content if it's too long

### DIFF
--- a/pkg/testresults/formatter.go
+++ b/pkg/testresults/formatter.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 )
 
-const dropdownSummaryString = "Click to view logs"
+const (
+	dropdownSummaryString = "Click to view logs"
+	maxContentChars       = 10000
+)
 
 // extractFailedTestCasesBody initialises the FailedTestCasesReport struct's
 // 'failedTestCaseNames' field with the names of failed test cases
@@ -64,5 +67,15 @@ func GetFormattedReport(report FailedTestCasesReport) (formattedReport string) {
 }
 
 func returnContentWrappedInDropdown(summary, content string) string {
-	return "<details><summary>" + summary + "</summary><br><pre>" + content + "</pre></details>\n\n---"
+	return "<details><summary>" + summary + "</summary><br><pre>" + returnTruncatedContent(content) + "</pre></details>\n\n---"
+}
+
+func returnTruncatedContent(content string) string {
+	if len(content) > maxContentChars {
+		runes := []rune(content)
+		truncatedRunes := runes[:maxContentChars]
+
+		return string(truncatedRunes) + "... the content is too long - please download the artifact to see the full content\n"
+	}
+	return content
 }

--- a/pkg/testresults/formatter.go
+++ b/pkg/testresults/formatter.go
@@ -67,7 +67,7 @@ func GetFormattedReport(report FailedTestCasesReport) (formattedReport string) {
 }
 
 func returnContentWrappedInDropdown(summary, content string) string {
-	return "<details><summary>" + summary + "</summary><br><pre>" + returnTruncatedContent(content) + "</pre></details>\n\n---"
+	return "<details><summary>" + summary + "</summary><br>\n<pre>" + returnTruncatedContent(content) + "</pre></details>\n\n---"
 }
 
 func returnTruncatedContent(content string) string {


### PR DESCRIPTION
## Fixes

1. This issue seen in `pull-request-comment` Task
```
step-pull-request-comment :-
/tekton/scripts/script-1-sxnt2: line 91: /usr/local/bin/jq: Argument list too long
```

It is coming from [this line](https://github.com/konflux-ci/tekton-integration-catalog/blob/ccae9c1279f2d40092116b9d4abe849332adf28c/tasks/pull-request-comment/0.1/pull-request-comment.yaml#L193)
It's caused by a test spec's log being too long

2. Cherry picks a commit from [this PR](https://github.com/konflux-ci/qe-tools/pull/149)

## Verification

Verified locally. The truncated content now looks like this:
<img width="1204" alt="Screenshot 2025-05-15 at 13 41 51" src="https://github.com/user-attachments/assets/ba54c04b-eb8d-4369-b7ac-b2427aa4aec6" />
